### PR TITLE
Allow files to contain unknown variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/BurntSushi/toml v1.0.0
-	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/buildpacks/pack v0.24.1
 	github.com/coveooss/gotemplate/v3 v3.7.2
 	github.com/gabriel-vasile/mimetype v1.4.0
@@ -14,13 +13,13 @@ require (
 	github.com/otiai10/copy v1.7.0
 	github.com/sclevine/spec v1.4.0
 	github.com/spf13/cobra v1.4.0
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 )
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
@@ -82,6 +81,7 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect

--- a/pkg/internal/init_test.go
+++ b/pkg/internal/init_test.go
@@ -11,4 +11,6 @@ func TestIternal(t *testing.T) {
 	spec.Run(t, "ReadPrompt", testReadPrompt, spec.Report(report.Terminal{}))
 	spec.Run(t, "Apply", testApply, spec.Report(report.Terminal{}))
 	spec.Run(t, "AskPrompts", testAskPrompts, spec.Report(report.Terminal{}))
+	spec.Run(t, "NoArgument", testApplyNoArgument, spec.Report(report.Terminal{}))
+	spec.Run(t, "Replace", testReplace, spec.Report(report.Terminal{}))
 }

--- a/pkg/internal/replace.go
+++ b/pkg/internal/replace.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/coveooss/gotemplate/v3/collections"
+	t "github.com/coveooss/gotemplate/v3/template"
+)
+
+func replaceUnknownVars(vars collections.IDictionary, content string) string {
+	regex := regexp.MustCompile(`{{[ \t]*\.\w+`)
+	transformed := content
+	for _, token := range regex.FindAllString(content, -1) {
+		candidate := strings.Split(token, ".")[1]
+		if !vars.Has(candidate) {
+			// replace "{{\s*.candidate" with "{&{&\s*.candidate"
+			replacement := strings.Replace(token, "{{", ReplacementDelimiter, 1)
+			transformed = strings.ReplaceAll(transformed, token, replacement)
+		}
+	}
+	return transformed
+}
+
+func Replace(vars collections.IDictionary, file SourceFile) (SourceFile, error) {
+	opts := t.DefaultOptions().
+		Set(t.Overwrite, t.Sprig, t.StrictErrorCheck, t.AcceptNoValue).
+		Unset(t.Razor)
+	template, err := t.NewTemplate(
+		"",
+		vars,
+		"",
+		opts)
+	if err != nil {
+		return SourceFile{}, err
+	}
+
+	filePath := replaceUnknownVars(vars, file.FilePath)
+	transformedFilePath, err := template.ProcessContent(filePath, "")
+	if err != nil {
+		return SourceFile{}, err
+	}
+	transformedFilePath = strings.ReplaceAll(transformedFilePath, ReplacementDelimiter, "{{")
+
+	transformedFileContent := ""
+	if file.FileContent != "" {
+		fileContent := replaceUnknownVars(vars, file.FileContent)
+		transformedFileContent, err = template.ProcessContent(fileContent, "")
+		if err != nil {
+			return SourceFile{}, err
+		}
+		transformedFileContent = strings.ReplaceAll(transformedFileContent, ReplacementDelimiter, "{{")
+	}
+
+	return SourceFile{FilePath: transformedFilePath, FileContent: transformedFileContent}, nil
+}

--- a/pkg/internal/replace_test.go
+++ b/pkg/internal/replace_test.go
@@ -1,0 +1,42 @@
+package internal_test
+
+import (
+	"testing"
+
+	h "github.com/buildpacks/pack/testhelpers"
+	"github.com/coveooss/gotemplate/v3/collections"
+	"github.com/sclevine/spec"
+
+	"github.com/AidanDelaney/scafall/pkg/internal"
+)
+
+func testReplace(t *testing.T, when spec.G, it spec.S) {
+	type TestCase struct {
+		file         internal.SourceFile
+		vars         collections.IDictionary
+		expectedName string
+	}
+
+	testCases := []TestCase{
+		{
+			internal.SourceFile{FilePath: "{{.Foo}}", FileContent: ""},
+			collections.CreateDictionary().Add("Foo", "Bar"),
+			"Bar",
+		},
+		{
+			internal.SourceFile{FilePath: "{{.Foo}}"},
+			collections.CreateDictionary().Add("Bar", "Bar"),
+			"{{.Foo}}",
+		},
+	}
+	for _, testCase := range testCases {
+		current := testCase
+		when("variable replacement is called", func() {
+			it("correctly replaces tokens", func() {
+				output, err := internal.Replace(current.vars, current.file)
+				h.AssertNil(t, err)
+				h.AssertEq(t, output.FilePath, current.expectedName)
+			})
+		})
+	}
+}

--- a/pkg/internal/transform.go
+++ b/pkg/internal/transform.go
@@ -1,21 +1,16 @@
 package internal
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/Masterminds/sprig/v3"
 	"github.com/coveooss/gotemplate/v3/collections"
-	t "github.com/coveooss/gotemplate/v3/template"
-	cp "github.com/otiai10/copy"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/manifoldco/promptui"
@@ -24,8 +19,9 @@ import (
 )
 
 const (
-	PromptFile   string = "prompts.toml"
-	OverrideFile string = ".override.toml"
+	PromptFile           string = "prompts.toml"
+	OverrideFile         string = ".override.toml"
+	ReplacementDelimiter string = "{&{&"
 )
 
 var (
@@ -127,13 +123,7 @@ func AskPrompts(prompts Prompts, overrides collections.IDictionary, input io.Rea
 }
 
 func ReadFile(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", fmt.Errorf("cannot open file %s", path)
-	}
-	defer file.Close()
-
-	buf, err := io.ReadAll(file)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot read file %s", path)
 	}
@@ -191,77 +181,46 @@ func ReadOverrides(overrideFile string) (collections.IDictionary, error) {
 	return oDict, nil
 }
 
+type SourceFile struct {
+	FilePath    string
+	FileContent string
+	FileMode    fs.FileMode
+}
+
 func Apply(inputDir string, vars collections.IDictionary, outputDir string) error {
-	transformedDir, _ := ioutil.TempDir("", "scafall")
-	defer os.RemoveAll(transformedDir)
 	files, err := findTransformableFiles(inputDir)
 	if err != nil {
 		return fmt.Errorf("failed to find files in input folder: %s %s", inputDir, err)
 	}
 
-	opts := t.DefaultOptions().
-		Set(t.Overwrite, t.Sprig, t.StrictErrorCheck).
-		Unset(t.Razor)
-	template, err := t.NewTemplate(
-		transformedDir,
-		vars,
-		"",
-		opts)
-	if err != nil {
-		return err
-	}
-
 	for _, file := range files {
-		// replace vars in file
-		filePath, _ := filepath.Rel(inputDir, file)
-		transformedFilePath, err := replace(vars, filePath)
+		outputFile, err := Replace(vars, file)
 		if err != nil {
-			return fmt.Errorf("failed to replace variable in filename: %s", file)
+			return err
 		}
-		dstPath := filepath.Join(transformedDir, transformedFilePath)
-		dstDir := filepath.Dir(dstPath)
+
+		dstDir := filepath.Join(outputDir, filepath.Dir(outputFile.FilePath))
 		mkdirErr := os.MkdirAll(dstDir, 0744)
 		if mkdirErr != nil {
 			return fmt.Errorf("failed to create target directory %s", dstDir)
 		}
-		mvErr := os.Rename(file, dstPath)
-		if mvErr != nil {
-			return fmt.Errorf("failed to rename %s to %s", filePath, transformedFilePath)
+
+		outputPath := filepath.Join(outputDir, outputFile.FilePath)
+		if outputFile.FileContent == "" {
+			mvErr := os.Rename(file.FilePath, outputPath)
+			if mvErr != nil {
+				return fmt.Errorf("failed to rename %s to %s", file.FilePath, outputFile.FilePath)
+			}
+		} else {
+			os.WriteFile(outputPath, []byte(outputFile.FileContent), outputFile.FileMode|0600)
 		}
 	}
 
-	absoluteFilepaths, err := findTextFiles(transformedDir)
-	if err != nil {
-		return err
-	}
-	_, err = template.ProcessTemplates(transformedDir, transformedDir, absoluteFilepaths...)
-	if err != nil {
-		return err
-	}
-
-	err = cp.Copy(transformedDir, outputDir)
-	if err != nil {
-		os.RemoveAll(outputDir)
-		return err
-	}
 	return err
 }
 
-func replace(env collections.IDictionary, data string) (string, error) {
-	var output bytes.Buffer
-	tpl, err := template.New("bp").Funcs(sprig.FuncMap()).Parse(data)
-	if err != nil {
-		return "", errors.New("cannot parse file template")
-	}
-	err = tpl.Execute(&output, env)
-	if err != nil {
-		return "", errors.New("cannot replace variables in file template")
-	}
-	return output.String(), err
-}
-
-func findTransformableFiles(dir string) ([]string, error) {
-	files := []string{}
+func findTransformableFiles(dir string) ([]SourceFile, error) {
+	files := []SourceFile{}
 	err := filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
 		if info.IsDir() && util.Contains(IgnoredDirectories, info.Name()) {
 			return filepath.SkipDir
@@ -274,7 +233,17 @@ func findTransformableFiles(dir string) ([]string, error) {
 				return nil
 			}
 
-			files = append(files, path)
+			relPath := strings.TrimPrefix(path, dir)
+			if isTextfile(path) {
+				fileContent, err := ReadFile(path)
+				if err != nil {
+					return err
+				}
+				fileMode := info.Type().Perm()
+				files = append(files, SourceFile{FilePath: relPath, FileContent: fileContent, FileMode: fileMode})
+			} else {
+				files = append(files, SourceFile{FilePath: relPath, FileContent: ""})
+			}
 		}
 		return nil
 	})
@@ -293,18 +262,4 @@ func isTextfile(path string) bool {
 	}
 
 	return strings.HasPrefix(mtype.String(), "text")
-}
-
-func findTextFiles(dir string) ([]string, error) {
-	files := []string{}
-	err := filepath.WalkDir(dir, func(path string, info os.DirEntry, err error) error {
-		if !info.IsDir() {
-			if isTextfile(path) && !util.Contains(IgnoredNames, info.Name()) {
-				files = append(files, path)
-			}
-		}
-		return nil
-	})
-
-	return files, err
 }

--- a/pkg/internal/transform.go
+++ b/pkg/internal/transform.go
@@ -207,7 +207,8 @@ func Apply(inputDir string, vars collections.IDictionary, outputDir string) erro
 
 		outputPath := filepath.Join(outputDir, outputFile.FilePath)
 		if outputFile.FileContent == "" {
-			mvErr := os.Rename(file.FilePath, outputPath)
+			inputPath := filepath.Join(inputDir, file.FilePath)
+			mvErr := os.Rename(inputPath, outputPath)
 			if mvErr != nil {
 				return fmt.Errorf("failed to rename %s to %s", file.FilePath, outputFile.FilePath)
 			}
@@ -233,7 +234,7 @@ func findTransformableFiles(dir string) ([]SourceFile, error) {
 				return nil
 			}
 
-			relPath := strings.TrimPrefix(path, dir)
+			relPath := strings.TrimPrefix(path, dir+"/")
 			if isTextfile(path) {
 				fileContent, err := ReadFile(path)
 				if err != nil {

--- a/pkg/internal/transform_test.go
+++ b/pkg/internal/transform_test.go
@@ -143,3 +143,53 @@ func testApply(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 }
+
+func testApplyNoArgument(t *testing.T, when spec.G, it spec.S) {
+	when("Applying to a file without argument", func() {
+		it("does not replace the template variable", func() {
+			tmpDir, _ := ioutil.TempDir("", "test")
+			defer os.RemoveAll(tmpDir)
+			outputDir, _ := ioutil.TempDir("", "test")
+			defer os.RemoveAll(outputDir)
+			testFile := filepath.Join(tmpDir, "test.txt")
+			content := "{{ .Foo }}"
+			os.WriteFile(testFile, []byte(content), 0600)
+
+			err := internal.Apply(tmpDir, collections.CreateDictionary(), outputDir)
+			h.AssertNil(t, err)
+
+			c, err := internal.ReadFile(filepath.Join(outputDir, "test.txt"))
+			h.AssertNil(t, err)
+			h.AssertContains(t, c, content)
+		})
+	})
+
+	when("Applying to a filesystem without argument", func() {
+		it("does not replace the template variable", func() {
+			tmpDir, _ := ioutil.TempDir("", "test")
+			defer os.RemoveAll(tmpDir)
+			outputDir, _ := ioutil.TempDir("", "test")
+			defer os.RemoveAll(outputDir)
+			err := os.MkdirAll(filepath.Join(tmpDir, "/{{.Foo}}/{{.Foo}}"), 0766)
+			h.AssertNil(t, err)
+			f, err := os.Create(filepath.Join(tmpDir, "/{{.Foo}}/{{.Foo}}/{{.Foo}}.txt"))
+			h.AssertNil(t, err)
+			f.Write([]byte("{{.Foo}}"))
+			f.Close()
+			vars := collections.CreateDictionary().Add("Bar", "bar")
+
+			err = internal.Apply(tmpDir, vars, outputDir)
+			h.AssertNil(t, err)
+
+			fooTxt := filepath.Join(outputDir, "/{{.Foo}}/{{.Foo}}/{{.Foo}}.txt")
+			foo, err := os.Stat(fooTxt)
+			h.AssertNil(t, err)
+			h.AssertNotNil(t, foo)
+
+			var c string
+			c, err = internal.ReadFile(filepath.Join(outputDir, "/{{.Foo}}/{{.Foo}}/{{.Foo}}.txt"))
+			h.AssertNil(t, err)
+			h.AssertContains(t, c, "{{.Foo}}")
+		})
+	})
+}


### PR DESCRIPTION
If a file contains "{{.Bar}}" but no Bar variable is defined, then we want to apply an identity transformation.  In this case, we replace "{{" with "&{&{", apply the transformation, then undo the replacement of the delimiter.